### PR TITLE
Add minimal GACCIA agent example

### DIFF
--- a/py-GACCIA/basic_agno_agent.py
+++ b/py-GACCIA/basic_agno_agent.py
@@ -1,39 +1,75 @@
-# https://docs.agno.com/examples/getting-started/basic-agent
+"""Basic demonstration of the GACCIA agent flow using agno.
+
+This is a minimal example of the competitive code improvement idea
+from the project README. It defines two simple agents, one for
+Python and one for TypeScript, and an orchestrator that routes
+code between them once.
+"""
+
+from __future__ import annotations
+
 from textwrap import dedent
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 
-# Create our News Reporter with a fun personality
-agent = Agent(
+
+# Agent that converts TypeScript to improved Python code
+python_agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
-    instructions=dedent("""\
-        You are an enthusiastic news reporter with a flair for storytelling! 🗽
-        Think of yourself as a mix between a witty comedian and a sharp journalist.
-
-        Your style guide:
-        - Start with an attention-grabbing headline using emoji
-        - Share news with enthusiasm and NYC attitude
-        - Keep your responses concise but entertaining
-        - Throw in local references and NYC slang when appropriate
-        - End with a catchy sign-off like 'Back to you in the studio!' or 'Reporting live from the Big Apple!'
-
-        Remember to verify all facts while keeping that NYC energy high!\
-    """),
+    instructions=dedent(
+        """
+        You are the **Python Architect** in the GACCIA project.
+        Convert incoming TypeScript code to Python.
+        Make the result clear and idiomatic.
+        """
+    ),
     markdown=True,
 )
 
-# Example usage
-agent.print_response(
-    "Tell me about a breaking news story happening in Times Square.", stream=True
+# Agent that converts Python to improved TypeScript code
+typescript_agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    instructions=dedent(
+        """
+        You are the **TypeScript Architect** in the GACCIA project.
+        Convert incoming Python code to TypeScript.
+        Make the result clear and idiomatic.
+        """
+    ),
+    markdown=True,
 )
 
-# More example prompts to try:
-"""
-Try these fun scenarios:
-1. "What's the latest food trend taking over Brooklyn?"
-2. "Tell me about a peculiar incident on the subway today"
-3. "What's the scoop on the newest rooftop garden in Manhattan?"
-4. "Report on an unusual traffic jam caused by escaped zoo animals"
-5. "Cover a flash mob wedding proposal at Grand Central"
-"""
+
+def improve_code(code: str, language_from: str) -> str:
+    """Convert ``code`` from ``language_from`` to the other language."""
+    lang = language_from.lower()
+    if lang == "python":
+        prompt = (
+            "Convert the following Python code to TypeScript and improve its readability:\n\n"
+            + code
+        )
+        return typescript_agent(prompt)
+    if lang in {"typescript", "ts"}:
+        prompt = (
+            "Convert the following TypeScript code to Python and improve its readability:\n\n"
+            + code
+        )
+        return python_agent(prompt)
+    raise ValueError(f"Unknown language: {language_from}")
+
+
+def orchestrate(code: str, language_from: str, rounds: int = 1) -> str:
+    """Run ``rounds`` of competitive improvement."""
+    current_code = code
+    current_lang = language_from
+    for _ in range(rounds):
+        current_code = improve_code(current_code, current_lang)
+        current_lang = "typescript" if current_lang.lower() == "python" else "python"
+    return current_code
+
+
+if __name__ == "__main__":
+    # Example usage with one round of conversion
+    demo_code = "print('hello world')"
+    print(orchestrate(demo_code, "python"))


### PR DESCRIPTION
## Summary
- rewrite `basic_agno_agent.py` with a small demo of the GACCIA agents
- show how Python and TypeScript agents can convert code and loop via an orchestrator

## Testing
- `python3 py-GACCIA/basic_agno_agent.py` *(fails: openAI and agno not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b7e74b6c88330b2ac5c0052e591b7