### PR TITLE
Fix import path for EnhancedGACCIAOrchestrator

### DIFF
--- a/py-GACCIA/test_images.py
+++ b/py-GACCIA/test_images.py
@@ -1,4 +1,4 @@
-from gaccia_agents_with_images import EnhancedGACCIAOrchestrator
+from gaccia_with_images import EnhancedGACCIAOrchestrator
 
 def test_single_image():
     orchestrator = EnhancedGACCIAOrchestrator()


### PR DESCRIPTION
## Summary
- update import in `test_images.py` to use `gaccia_with_images`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683bb95253288330a84d55610d6a3ca3