### PR TITLE
Fix results path consistency

### DIFF
--- a/py-GACCIA/gaccia_main.py
+++ b/py-GACCIA/gaccia_main.py
@@ -119,10 +119,15 @@ class GACCIAComplete:
         completed_session = CompletedGACCIASession(session, evaluation)
 
         logger.save_summary(session, evaluation)
-        
+
         # Print results
         self._print_final_results(completed_session)
-        
+
+        # Save full session results to the same directory used by the logger
+        self.save_complete_results(
+            completed_session, results_dir=logger.base_dir
+        )
+
         return completed_session
     
     def _print_final_results(self, completed_session: CompletedGACCIASession):
@@ -152,12 +157,18 @@ class GACCIAComplete:
         
         print("\n" + "=" * 80)
     
-    def save_complete_results(self, completed_session: CompletedGACCIASession, custom_name: Optional[str] = None) -> Path:
+    def save_complete_results(
+        self,
+        completed_session: CompletedGACCIASession,
+        custom_name: Optional[str] = None,
+        results_dir: Optional[Path] = None,
+    ) -> Path:
         """Save all results from the completed session."""
-        
-        # Create results directory
-        session_name = custom_name or f"gaccia_session_{completed_session.session.session_id[:8]}"
-        results_dir = Path("results") / session_name
+
+        # Determine results directory
+        if results_dir is None:
+            session_name = custom_name or f"gaccia_session_{completed_session.session.session_id[:8]}"
+            results_dir = Path("results") / session_name
         results_dir.mkdir(parents=True, exist_ok=True)
         
         # Save original code

--- a/py-GACCIA/results_manager.py
+++ b/py-GACCIA/results_manager.py
@@ -14,7 +14,9 @@ class ResultsLogger:
 
     def __init__(self, session_name: str):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.base_dir = Path(__file__).parent / "results" / f"{timestamp}_{session_name}"
+        # Use repo-level results directory so all components store data in the
+        # same place regardless of where this module lives.
+        self.base_dir = Path("results") / f"{timestamp}_{session_name}"
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     def log_round(self, round_num: int, impl: CodeImplementation) -> None:


### PR DESCRIPTION
## Summary
- centralize session outputs under the repo `results/` directory
- keep the chosen results directory across image generation and final saves

## Testing
- `python -m py_compile py-GACCIA/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683bbdcb41f88330885bce5767702cc9